### PR TITLE
Fix race condition with libmodbus build config error

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /go/src/github.com/hitachi-vantara-edge/modbus-service
 COPY . .
 RUN cd build/libmodbus-3.1.4 \
 && apt-get update \
-&& apt-get -y install build-essential \
-&& ./configure && make && make install && cp config.h ../../cmd/modbus/ \
+&& apt-get -y install build-essential autoconf libtool \
+&& autoreconf -f -i && ./configure && make && make install \
+&& cp config.h ../../cmd/modbus/ \
 && cd ../.. \
 && go build ./cmd/modbus/main.go
 


### PR DESCRIPTION
It seems that the build issue in the following failed build: https://circleci.com/gh/hitachi-vantara-edge/modbus-service/16 might be related because Git does not preserve files' timestamps, so the configure script might appear to be out of date.
The recommendation I found online was to execute `autoreconf` before `./configure` to hopefully avoid this issue.